### PR TITLE
fix: expand home config paths

### DIFF
--- a/config.go
+++ b/config.go
@@ -5,6 +5,8 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -35,11 +37,32 @@ var ConfigPaths = [6]string{
 
 func FindConfig() (string, error) {
 	for _, path := range ConfigPaths {
+		path = expandHomePath(path)
 		if _, err := os.Stat(path); err == nil {
 			return path, nil
 		}
 	}
 	return "", errors.New("Failed to locate a config file: ./connectivity.yml ~/.connectivity.yml or /etc/connectivity.yml")
+}
+
+func expandHomePath(path string) string {
+	if path == "~" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return path
+		}
+		return home
+	}
+
+	if strings.HasPrefix(path, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return path
+		}
+		return filepath.Join(home, path[2:])
+	}
+
+	return path
 }
 
 func LoadConfig(path string) *Config {

--- a/config_test.go
+++ b/config_test.go
@@ -182,6 +182,38 @@ func TestLoadConfig_MissingFileFatals(t *testing.T) {
 	}
 }
 
+func TestFindConfig_ExpandsHomeConfigPath(t *testing.T) {
+	home := t.TempDir()
+	cwd := t.TempDir()
+	t.Setenv("HOME", home)
+
+	configPath := filepath.Join(home, ".connectivity.yml")
+	if err := os.WriteFile(configPath, []byte("example: http://example.com\n"), 0o600); err != nil {
+		t.Fatalf("os.WriteFile(%q): %v", configPath, err)
+	}
+
+	prev, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("os.Getwd: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(prev); err != nil {
+			t.Fatalf("os.Chdir(%q): %v", prev, err)
+		}
+	})
+	if err := os.Chdir(cwd); err != nil {
+		t.Fatalf("os.Chdir(%q): %v", cwd, err)
+	}
+
+	path, err := FindConfig()
+	if err != nil {
+		t.Fatalf("FindConfig() error = %v; want nil", err)
+	}
+	if path != configPath {
+		t.Errorf("FindConfig() path = %q; want %q", path, configPath)
+	}
+}
+
 func TestFindConfig_ReturnsErrorWhenNoneExist(t *testing.T) {
 	// Run in a temp dir so the current working directory does not contain
 	// any of the relative ConfigPaths (connectivity.yml, etc).


### PR DESCRIPTION
<!-- hermes-auto-maintainer -->

## Summary
- Expand `~/` config search paths at lookup time so documented home config files are found.
- Return the expanded absolute config path from `FindConfig`.
- Add a regression test using an isolated temporary HOME and working directory.

## Test plan
- `go test -run TestFindConfig_ExpandsHomeConfigPath`
- `go test -race -run TestFindConfig_ExpandsHomeConfigPath`
- `go vet ./...`
- `go build ./...`
- `gofmt -l .`
- `git diff --check`

Full-suite note:
- `go test ./...` and `go test -race ./...` still fail on `TestMinimalPostgresUrl` with `lookup tcp/postgres: unknown port`; the same `go test ./...` failure reproduces on `origin/main`, so it is unrelated to this change.

Fixes #9
