### PR TITLE
docs: document connectivity commands and config paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Given a set of URLs, connectivity attempts to validate each one as thoroughly as
 
 3. The routability of each address is evaluated. Failures in routability are non-fatal; that is, the attempt to determine a viable route is only useful for producing robust logging upon failure, but does not indicate a failure in the actual routability from the host.
 
-4. Each address returned by DNS is dialed to validate the network path (or pinged, in the case of URLs like `icmp://<host>`.
+4. Each address returned by DNS is dialed to validate the network path (or pinged, in the case of URLs like `icmp://<host>`). Every returned address must pass for the destination to be considered reachable.
 
 5. Supported schemes are then validated at the application-level (attempting to make real HTTP requests in the case of `http://` or `https://`, for example).
 
@@ -18,19 +18,24 @@ If any step in the validation process fails, relevant debugging information is l
 
 ## Configuration
 
-`connectivity` looks for a configuration file in the following three locations, and uses the first one it finds:
+`connectivity` looks for a configuration file in the following locations, and uses the first one it finds:
 
 - `./connectivity.yml`
+- `./connectivity.yaml`
 - `~/.connectivity.yml`
+- `~/.connectivity.yaml`
 - `/etc/connectivity.yml`
+- `/etc/connectivity.yaml`
 
 Without a configuration file, you might use `connectivity` to validate multiple types of connectivity to one or more destinations:
 
 ```bash
-connectivity [check|wait|monitor] icmp://example.com tcp://example.com:443/ udp://example.com:53 http://example.com/health https://example.com/health
+connectivity check icmp://example.com tcp://example.com:443/ udp://example.com:53 http://example.com/health https://example.com/health
 ```
 
-With a YAML configuration file, you can simply invoke `connectivity` using `connectivity [check|wait|monitor]`. Configuration uses arbitrary key-value pairs, where the key is used as a label for logging purposes (instead of logging the entire URL), and the value is the URL to be validated (which would otherwise be passed on the command line).
+With a YAML configuration file, you can simply invoke `connectivity` using `connectivity check`, `connectivity wait`, or `connectivity monitor`. Configuration uses arbitrary key-value pairs, where the key is used as a label for logging purposes (instead of logging the entire URL), and the value is the URL to be validated (which would otherwise be passed on the command line).
+
+If both a configuration file and command-line URLs are provided, command-line URLs replace the configured destinations for that run.
 
 ```yaml
 ---
@@ -41,18 +46,49 @@ HTTP: http://example.com/health
 HTTPS: https://example.com/health
 ```
 
+### Commands
+
+`connectivity` supports the following subcommands:
+
+- `check`: check all destinations once and exit.
+- `wait`: wait until all destinations validate successfully at least once.
+- `waitfor`: alias for `wait`.
+- `monitor`: continuously monitor all destinations.
+- `validate-config`: load and validate configuration without making network requests.
+- `version`: print build/version metadata.
+- `help`: print general help; `connectivity help <command>` prints per-command help.
+
+### Statsd
+
+Connectivity emits result and timing metrics through statsd. By default metrics are sent to `127.0.0.1:8125` over UDP. The statsd settings and defaults are:
+
+| Setting | Default |
+| --- | --- |
+| `statsd_host` | `127.0.0.1` |
+| `statsd_port` | `8125` |
+| `statsd_protocol` | `udp` |
+
+`statsd_protocol` may be `udp` or `tcp`. Parsing custom YAML values for these settings is tracked separately in #6.
+
+### Exit codes
+
+- `0`: success, help/version output, or successful configuration validation.
+- `1`: a connectivity check failed, or no destinations were parsed.
+- `2`: invalid command or destination parse error.
+
 ## Supported schemes
 
 `connectivity` can be used to validate connectivity at various different layers of the [OSI model](https://en.wikipedia.org/wiki/OSI_model).
 
 OSI Layer 3 (Network):
 
-- `icmp://`: Validate the destination by pinging it (ICMP). You must not specify a port. Response time metrics are emitted via statsd.
+- `icmp://`: Validate the destination by pinging it (ICMP). You must not specify a port. ICMP checks usually require root or `CAP_NET_RAW` on Linux, equivalent container capability such as `--cap-add=NET_RAW`, or platform-specific unprivileged ICMP support. Response time metrics are emitted via statsd.
 
 OSI Layer 4 (Transport):
 
 - `tcp://`: Simply dial the host at the specified port and hangup (a port is required). This is useful for validating raw connectivity (similar to `netcat`) without validating anything futher about the connection. Layer 7 firewalls may allow this check to succeed, but deny the application-specific traffic, such as TLS negotiation.
 - `udp://`: Simply dial the host at the specified port (a port is required). It is impossible to guarantee the destination was actually reached, only that packets _can_ be sent.
+- Schemes known to the system services database, such as `mysql://`, `postgresql://`, `ssh://`, or `ftp://` when those service names are registered locally, are treated as TCP dial checks using the registered default port. Service-name availability is OS-dependent. `nats://` is also supported as a special case with default port `4222`.
 
 OSI Layer 7 (Application):
 

--- a/config.go
+++ b/config.go
@@ -39,7 +39,7 @@ func FindConfig() (string, error) {
 			return path, nil
 		}
 	}
-	return "", errors.New("Failed to locate a config file: ./connectivity.yml ~/.connectivity.yml or /etc/connectivity.yml")
+	return "", errors.New("Failed to locate a config file: ./connectivity.yml, ./connectivity.yaml, ~/.connectivity.yml, ~/.connectivity.yaml, /etc/connectivity.yml, or /etc/connectivity.yaml")
 }
 
 func LoadConfig(path string) *Config {

--- a/help.go
+++ b/help.go
@@ -76,11 +76,14 @@ func PrintCommandUsage(command string) bool {
 		fmt.Println("")
 		fmt.Println("Any validation errors will produce a non-zero return code (1). Only the config")
 		fmt.Println("file at the specified path is validated. If no config file is specified, then")
-		fmt.Println("the first config file discovered in order order of precedence is validated:")
+		fmt.Println("the first config file discovered in order of precedence is validated:")
 		fmt.Println("")
 		fmt.Println("- ./connectivity.yml")
+		fmt.Println("- ./connectivity.yaml")
 		fmt.Println("- ~/.connectivity.yml")
+		fmt.Println("- ~/.connectivity.yaml")
 		fmt.Println("- /etc/connectivity.yml")
+		fmt.Println("- /etc/connectivity.yaml")
 	} else {
 		PrintUsage()
 		return false

--- a/help_test.go
+++ b/help_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = w
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("pipe close: %v", err)
+	}
+	os.Stdout = old
+
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("io.ReadAll: %v", err)
+	}
+	return string(out)
+}
+
+func TestPrintCommandUsageValidateConfigListsYamlVariants(t *testing.T) {
+	out := captureStdout(t, func() {
+		if !PrintCommandUsage("validate-config") {
+			t.Fatalf("PrintCommandUsage(validate-config) = false; want true")
+		}
+	})
+
+	for _, want := range []string{
+		"./connectivity.yml",
+		"./connectivity.yaml",
+		"~/.connectivity.yml",
+		"~/.connectivity.yaml",
+		"/etc/connectivity.yml",
+		"/etc/connectivity.yaml",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("validate-config help missing %q in output:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "order order") {
+		t.Errorf("validate-config help contains duplicated word: %q", out)
+	}
+}


### PR DESCRIPTION
<!-- hermes-auto-maintainer -->

## Summary
- Document the full command surface in the README, including `waitfor`, `validate-config`, `version`, and per-command help.
- Align config-path documentation and `validate-config` help with the `.yaml` variants that `ConfigPaths` already probes.
- Add README notes for statsd defaults, exit codes, ICMP privileges, all-DNS-record success semantics, CLI URL precedence, and OS-dependent `/etc/services` scheme handling.
- Add a focused regression test for the `validate-config` help output.

Fixes #33

## Test Plan
- RED: with the original `help.go`, `go test ./... -run TestPrintCommandUsageValidateConfigListsYamlVariants -count=1` failed because `.yaml` paths were missing and the help text contained `order order`.
- GREEN: `go test ./... -run 'TestPrintCommandUsageValidateConfigListsYamlVariants|TestLoadConfig_MinimalYAMLAppliesDefaults|TestFindConfig_ReturnsErrorWhenNoneExist|TestMinimalMysqlUrl|TestMinimalNatsUrl' -count=1`
- `go test ./... -run '^$' -count=1`
- `gofmt -w config.go help.go help_test.go`
- Source proof checked README/help/config documentation strings and `git diff --no-index --check` reported no whitespace errors.

## Notes
- Full `go test ./... -count=1` was attempted on macOS and is still blocked by existing `TestMinimalPostgresUrl` behavior: this host's services database has `postgresql` but not `postgres`, so `net.LookupPort("tcp", "postgres")` fails and the existing test panics before this PR's changes are involved.
- This is a docs/help-text/test PR; it should use `release:skip` per `AGENTS.md` if maintainers can apply labels.
