### PR TITLE
test: add benchmarks for connectivity hot paths

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
 
+if [ "${1:-}" = "bench" ]; then
+    go test -bench=. -benchmem ./...
+    exit 0
+fi
+
 # Vet
 go vet
 
@@ -8,8 +13,12 @@ go vet
 GIT_COMMIT="$(git rev-parse --short HEAD)"
 GIT_TAG="$(git tag --points-at HEAD)"
 GO_VERSION="$(go version | cut -d' ' -f3)"
-BUILD_DATE="$(date --utc)"
-BUILD_ARCH="$(arch)"
+if date --utc >/dev/null 2>&1; then
+    BUILD_DATE="$(date --utc)"
+else
+    BUILD_DATE="$(date -u)"
+fi
+BUILD_ARCH="$(uname -m)"
 if [ "$(git status -s | wc -l)" -eq "0" ]; then
     BUILD_TAINTED=false
 else

--- a/destinations_bench_test.go
+++ b/destinations_bench_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"testing"
+)
+
+func BenchmarkDestinationIncrement(b *testing.B) {
+	dest, err := NewDestination(Url{Label: "x", Url: "https://example.com"})
+	if err != nil {
+		b.Fatal(err)
+	}
+	done := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-queue:
+			case <-done:
+				return
+			}
+		}
+	}()
+	defer close(done)
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		dest.Increment("connectivity.check", nil)
+	}
+}

--- a/resolver_bench_test.go
+++ b/resolver_bench_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"testing"
+)
+
+func BenchmarkLookup(b *testing.B) {
+	dest, err := NewDestination(Url{Label: "localhost", Url: "http://127.0.0.1"})
+	if err != nil {
+		b.Fatal(err)
+	}
+	done := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-queue:
+			case <-done:
+				return
+			}
+		}
+	}()
+	defer close(done)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := Lookup(dest); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/source_bench_test.go
+++ b/source_bench_test.go
@@ -1,0 +1,10 @@
+package main
+
+import "testing"
+
+func BenchmarkGetLocalIPs(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = GetLocalIPs()
+	}
+}

--- a/statsd_bench_test.go
+++ b/statsd_bench_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"testing"
+)
+
+func BenchmarkIncrement(b *testing.B) {
+	done := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-queue:
+			case <-done:
+				return
+			}
+		}
+	}()
+	defer close(done)
+
+	tags := []string{"dest_host:example.com", "dest_port:443"}
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		Increment("connectivity.check", tags)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `BenchmarkLookup`, `BenchmarkGetLocalIPs`, `BenchmarkIncrement`, and `BenchmarkDestinationIncrement` with `ReportAllocs` and queue draining
- Add `./build.sh bench` running `go test -bench=. -benchmem ./...`

Fixes #35