### PR TITLE
docs: add contributor and security onboarding files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,42 @@
+name: Bug report
+description: Report a problem running connectivity
+labels: [bug]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: What you expected vs what you observed.
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: connectivity version
+      description: Output of `connectivity version` or the release tag you installed.
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: OS / environment
+      description: e.g. Ubuntu 22.04, Kubernetes sidecar, bare metal.
+    validations:
+      required: true
+  - type: textarea
+    id: command
+    attributes:
+      label: Command
+      description: Exact command line you ran.
+    validations:
+      required: true
+  - type: textarea
+    id: config
+    attributes:
+      label: Config (if any)
+      description: Relevant `connectivity.yml` snippet (redact secrets).
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: Relevant log output.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## Summary
+
+<!-- What does this PR change and why? -->
+
+## Checklist
+
+- [ ] `go vet ./...` passes
+- [ ] `go test ./...` passes (and `-race` for concurrency changes)
+- [ ] Tests added or updated for behavior changes
+- [ ] README / docs updated if user-facing behavior changed
+- [ ] Release label set (`release:patch` / `release:minor` / `release:major` / `release:skip`)
+
+Fixes #

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing to connectivity
+
+Thanks for your interest in improving `connectivity`.
+
+## Development setup
+
+- Go 1.20+ (see `go.mod`)
+- Linux is the primary target; routing checks require Linux for full behavior
+
+## Build and test
+
+```bash
+./build.sh          # vet, build, and test with coverage
+./build.sh bench    # run benchmarks
+go test -race ./... # recommended before sending a PR
+```
+
+## Pull requests
+
+1. Open an issue first for non-trivial changes so we can agree on approach.
+2. Keep PRs focused — one logical change per PR.
+3. Add or update tests for behavior changes.
+4. Ensure `go vet ./...` and `go test ./...` pass locally.
+
+## Release labels
+
+Merged PRs to `main` are released automatically when CI passes. Add one of these labels to the PR:
+
+| Label | Effect |
+|-------|--------|
+| `release:patch` | Bug fix (default) |
+| `release:minor` | Backwards-compatible feature |
+| `release:major` | Breaking change |
+| `release:skip` | No release |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security policy
+
+## Reporting a vulnerability
+
+Please **do not** open a public GitHub issue for security vulnerabilities.
+
+Report security issues privately by opening a [GitHub Security Advisory](https://github.com/dolph/connectivity/security/advisories/new) on this repository, or by emailing the repository owner through their GitHub profile.
+
+We aim to acknowledge reports within **5 business days** and will work with you on a fix and coordinated disclosure timeline.
+
+## Supported versions
+
+Security fixes are applied to the latest release on the `main` branch. Older tagged releases are not maintained separately unless a critical issue warrants a backport.


### PR DESCRIPTION
## Summary
- Add `CONTRIBUTING.md` with build/test/PR expectations
- Add `SECURITY.md` with private reporting via GitHub Security Advisories
- Add bug report issue template and PR checklist

Fixes #27