### PR TITLE
chore: attach license bundle and SHA256 checksum to releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,6 +110,17 @@ jobs:
           file connectivity
           ./connectivity version
 
+      - name: Generate third-party licenses
+        if: steps.bump.outputs.bump != 'skip'
+        run: |
+          set -euo pipefail
+          chmod +x scripts/generate-third-party-licenses.sh
+          ./scripts/generate-third-party-licenses.sh THIRD_PARTY_LICENSES.txt
+
+      - name: Generate checksum
+        if: steps.bump.outputs.bump != 'skip'
+        run: sha256sum connectivity > connectivity.sha256
+
       - name: Create and push annotated tag
         if: steps.bump.outputs.bump != 'skip'
         env:
@@ -129,14 +140,15 @@ jobs:
           HAS_PREV: ${{ steps.ver.outputs.has_prev }}
         run: |
           set -euo pipefail
+          assets=(connectivity connectivity.sha256 THIRD_PARTY_LICENSES.txt)
           if [ "${HAS_PREV}" = "true" ]; then
-            gh release create "${TAG}" connectivity \
+            gh release create "${TAG}" "${assets[@]}" \
               --target "${HEAD_SHA}" \
               --title "${TAG}" \
               --generate-notes \
               --notes-start-tag "${PREV}"
           else
-            gh release create "${TAG}" connectivity \
+            gh release create "${TAG}" "${assets[@]}" \
               --target "${HEAD_SHA}" \
               --title "${TAG}" \
               --generate-notes

--- a/scripts/generate-third-party-licenses.sh
+++ b/scripts/generate-third-party-licenses.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Generate THIRD_PARTY_LICENSES.txt for release redistribution.
+# Requires: go install github.com/google/go-licenses/v2@v2.0.1
+
+root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$root"
+
+out="${1:-THIRD_PARTY_LICENSES.txt}"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+go install github.com/google/go-licenses/v2@v2.0.1
+go-licenses save ./... --save_path="$tmp/licenses" --force
+
+{
+  echo "Third-party licenses for connectivity"
+  echo "Generated: $(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+  echo
+  find "$tmp/licenses" -type f | sort | while read -r f; do
+    echo "================================================================================"
+    echo "${f#"$tmp/licenses"/}"
+    echo "================================================================================"
+    cat "$f"
+    echo
+  done
+} >"$out"
+
+echo "Wrote $out"


### PR DESCRIPTION
## Summary
- Add `scripts/generate-third-party-licenses.sh` using `go-licenses save` to produce `THIRD_PARTY_LICENSES.txt`
- Attach `THIRD_PARTY_LICENSES.txt` and `connectivity.sha256` to each GitHub release alongside the binary

Fixes #36
Fixes #26