### PR TITLE
perf: reuse routing table across GetRoute calls

### DIFF
--- a/router.go
+++ b/router.go
@@ -3,9 +3,6 @@ package main
 import (
 	"fmt"
 	"net"
-	"os"
-
-	"github.com/google/gopacket/routing"
 )
 
 type Route struct {
@@ -31,25 +28,15 @@ func (r *Route) String() string {
 }
 
 func GetRoute(ip net.IP) (*Route, error) {
-	hostname, err := os.Hostname()
-	if err != nil {
-		hostname = "localhost"
-	}
-
 	route := &Route{
-		SourceHostname:        hostname,
+		SourceHostname:        routeHostname,
 		SourceInterfaceName:   "",
 		SourceHardwareAddress: nil,
 		SourceIP:              nil,
 		GatewayIP:             nil,
 		DestinationIP:         ip}
 
-	r, err := routing.New()
-	if err != nil {
-		return route, err
-	}
-
-	iface, gateway, source, err := r.Route(ip)
+	iface, gateway, source, err := lookupRoute(ip)
 	if err != nil {
 		// This is possibly a workaround until something like https://github.com/google/gopacket/pull/697 is released
 		return route, err

--- a/router_cache.go
+++ b/router_cache.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"errors"
+	"net"
+	"os"
+	"sync"
+
+	"github.com/google/gopacket/routing"
+)
+
+var errRouteTableUnavailable = errors.New("route table unavailable")
+
+var (
+	routeRouterMu sync.RWMutex
+	routeRouter   routing.Router
+	routeHostname string
+)
+
+func init() {
+	routeHostname, _ = os.Hostname()
+	if routeHostname == "" {
+		routeHostname = "localhost"
+	}
+}
+
+func refreshRouteRouter() {
+	var r routing.Router
+	var err error
+	func() {
+		defer func() {
+			if recover() != nil {
+				err = errRouteTableUnavailable
+			}
+		}()
+		r, err = routing.New()
+	}()
+	routeRouterMu.Lock()
+	defer routeRouterMu.Unlock()
+	if err == nil && r != nil {
+		routeRouter = r
+	}
+}
+
+func lookupRoute(ip net.IP) (*net.Interface, net.IP, net.IP, error) {
+	routeRouterMu.RLock()
+	r := routeRouter
+	routeRouterMu.RUnlock()
+
+	if r == nil {
+		refreshRouteRouter()
+		routeRouterMu.RLock()
+		r = routeRouter
+		routeRouterMu.RUnlock()
+	}
+
+	if r == nil {
+		return nil, nil, nil, errRouteTableUnavailable
+	}
+
+	iface, gateway, source, err := r.Route(ip)
+	if err == nil {
+		return iface, gateway, source, nil
+	}
+
+	refreshRouteRouter()
+	routeRouterMu.RLock()
+	r = routeRouter
+	routeRouterMu.RUnlock()
+	if r == nil {
+		return nil, nil, nil, err
+	}
+	return r.Route(ip)
+}
+
+func clearRouteRouterForTest() {
+	routeRouterMu.Lock()
+	routeRouter = nil
+	routeRouterMu.Unlock()
+	refreshRouteRouter()
+}

--- a/router_cache_test.go
+++ b/router_cache_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"net"
+	"testing"
+)
+
+func TestLookupRouteReusesCachedRouter(t *testing.T) {
+	clearRouteRouterForTest()
+	t.Cleanup(clearRouteRouterForTest)
+
+	ip := net.ParseIP("127.0.0.1")
+	if _, err := GetRoute(ip); err != nil {
+		t.Skipf("routing unavailable on this platform: %v", err)
+	}
+
+	routeRouterMu.RLock()
+	first := routeRouter
+	routeRouterMu.RUnlock()
+	if first == nil {
+		t.Fatal("expected cached router after first lookup")
+	}
+
+	if _, err := GetRoute(ip); err != nil {
+		t.Fatalf("second GetRoute: %v", err)
+	}
+
+	routeRouterMu.RLock()
+	second := routeRouter
+	routeRouterMu.RUnlock()
+	if first != second {
+		t.Error("expected same routing.Router instance on second lookup")
+	}
+}


### PR DESCRIPTION
## Summary
- Cache `routing.New()` in a package-level router, refreshed on lookup failure
- Resolve hostname once at init instead of per check
- Recover from `routing.New()` panic on unsupported platforms

Fixes #30