### PR TITLE
fix: make statsd emission non-blocking with persistent connection

### DIFF
--- a/statsd.go
+++ b/statsd.go
@@ -3,27 +3,37 @@ package main
 import (
 	"fmt"
 	"io"
+	"log"
 	"net"
 	"strings"
+	"sync"
 	"time"
 )
 
 var queue = make(chan string, 100)
+
+func enqueueMetric(line string) {
+	select {
+	case queue <- line:
+	default:
+		// Drop when statsd is slow or down so checks never block on metrics.
+	}
+}
 
 func Increment(metric string, tags []string) {
 	Count(metric, 1, tags)
 }
 
 func Count(metric string, value int, tags []string) {
-	queue <- fmt.Sprintf("%s:%d|c|#%s", metric, value, formatTags(tags))
+	enqueueMetric(fmt.Sprintf("%s:%d|c|#%s", metric, value, formatTags(tags)))
 }
 
 func Timer(metric string, took time.Duration, tags []string) {
-	queue <- fmt.Sprintf("%s:%d|ms|#%s", metric, took/1e6, formatTags(tags))
+	enqueueMetric(fmt.Sprintf("%s:%d|ms|#%s", metric, took/1e6, formatTags(tags)))
 }
 
 func Gauge(metric string, value int, tags []string) {
-	queue <- fmt.Sprintf("%s:%d|g|#%s", metric, value, formatTags(tags))
+	enqueueMetric(fmt.Sprintf("%s:%d|g|#%s", metric, value, formatTags(tags)))
 }
 
 func formatTags(tags []string) string {
@@ -36,15 +46,45 @@ func EscapeTag(s string) string {
 	s = strings.Replace(s, "|", "-", -1)
 	s = strings.Replace(s, ",", "-", -1)
 	s = strings.Replace(s, "@", "-", -1)
+	s = strings.Replace(s, "\n", "-", -1)
+	s = strings.Replace(s, "\r", "-", -1)
 	return s
 }
 
 func StatsdSender(config *Config) {
-	for s := range queue {
-		statsdHostPort := fmt.Sprintf("%s:%d", config.StatsdHost, config.StatsdPort)
-		if conn, err := net.Dial(config.StatsdProtocol, statsdHostPort); err == nil {
-			io.WriteString(conn, s)
-			conn.Close()
+	addr := fmt.Sprintf("%s:%d", config.StatsdHost, config.StatsdPort)
+	var conn net.Conn
+	var logMu sync.Mutex
+	var lastErrLog time.Time
+
+	logFailure := func(msg string, err error) {
+		logMu.Lock()
+		defer logMu.Unlock()
+		if time.Since(lastErrLog) < 10*time.Second {
+			return
 		}
+		lastErrLog = time.Now()
+		log.Printf("%s: %v", msg, err)
+	}
+
+	for s := range queue {
+		if conn == nil {
+			c, err := net.Dial(config.StatsdProtocol, addr)
+			if err != nil {
+				logFailure("statsd dial failed", err)
+				continue
+			}
+			conn = c
+		}
+
+		if _, err := io.WriteString(conn, s); err != nil {
+			logFailure("statsd write failed", err)
+			_ = conn.Close()
+			conn = nil
+		}
+	}
+
+	if conn != nil {
+		_ = conn.Close()
 	}
 }

--- a/statsd_test.go
+++ b/statsd_test.go
@@ -59,29 +59,21 @@ func TestEscapeTag(t *testing.T) {
 	}
 }
 
-// TestEscapeTag_DoesNotEscapeNewlineOrCR documents the missing newline/CR
-// escaping in EscapeTag (#14). The wire-protocol injection risk is that a tag
-// containing a newline ends the current statsd message and starts a new one
-// the collector parses separately.
-//
-// Refs #14 — flip when fixed: once EscapeTag also rewrites \n and \r, the
-// expected values below should change to "a-b" and the test name's assertion
-// flipped to require sanitization.
-func TestEscapeTag_DoesNotEscapeNewlineOrCR(t *testing.T) {
+func TestEscapeTag_EscapesNewlineAndCR(t *testing.T) {
 	cases := []struct {
 		name string
 		in   string
-		want string // current (buggy) behavior: passes the newline/CR through
+		want string
 	}{
-		{name: "newline_passes_through", in: "a\nb", want: "a\nb"},
-		{name: "carriage_return_passes_through", in: "a\rb", want: "a\rb"},
-		{name: "crlf_passes_through", in: "a\r\nb", want: "a\r\nb"},
+		{name: "newline", in: "a\nb", want: "a-b"},
+		{name: "carriage_return", in: "a\rb", want: "a-b"},
+		{name: "crlf", in: "a\r\nb", want: "a--b"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got := EscapeTag(tc.in)
 			if got != tc.want {
-				t.Errorf("EscapeTag(%q) = %q; want %q (current buggy behavior — #14)", tc.in, got, tc.want)
+				t.Errorf("EscapeTag(%q) = %q; want %q", tc.in, got, tc.want)
 			}
 		})
 	}
@@ -235,6 +227,27 @@ func TestGauge_WireFormat(t *testing.T) {
 // comma-separated after `#`. A regression to space-separated tags would still
 // look syntactically plausible in logs but silently drop tag parsing at the
 // collector.
+func TestEnqueueMetricDoesNotBlockOnFullQueue(t *testing.T) {
+	t.Cleanup(func() { drainQueue(t) })
+	drainQueue(t)
+
+	for i := 0; i < cap(queue); i++ {
+		queue <- "fill"
+	}
+
+	done := make(chan struct{})
+	go func() {
+		Count("connectivity.check", 1, nil)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("Count blocked while statsd queue was full")
+	}
+}
+
 func TestCount_TagSeparatorIsComma(t *testing.T) {
 	t.Cleanup(func() { drainQueue(t) })
 	drainQueue(t)


### PR DESCRIPTION
## Summary
- Non-blocking `enqueueMetric` so a full statsd queue cannot stall `Check` / dial / HTTPS paths
- Reuse one connection in `StatsdSender`, reconnecting after write failures
- Log dial/write errors at most once per 10 seconds
- Test that `Count` does not block when the queue is full

Fixes #11