### PR TITLE
feat: add doctor subcommand for verbose diagnostics

### DIFF
--- a/connectivity.go
+++ b/connectivity.go
@@ -68,6 +68,23 @@ func main() {
 		ShowDestinations(destinations)
 		log.Print("Monitoring connectivity...")
 		MonitorLoop(destinations)
+	} else if command == "doctor" {
+		if len(os.Args) < 3 {
+			log.Fatal("usage: connectivity doctor <url> [urls...]")
+		}
+		configPath, _ := FindConfig()
+		config := LoadConfig(configPath)
+		go StatsdSender(config)
+		var urls []Url
+		for _, raw := range os.Args[2:] {
+			urls = append(urls, Url{Url: raw})
+		}
+		destinations := ParseDestinations(urls)
+		ShowDestinations(destinations)
+		if DoctorLoop(destinations) {
+			os.Exit(0)
+		}
+		os.Exit(1)
 	} else if command == "version" {
 		PrintVersion()
 	} else if command == "help" {

--- a/doctor.go
+++ b/doctor.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// Doctor runs each connectivity layer with verbose logging for incident triage.
+func (dest *Destination) Doctor() bool {
+	LogDestination(dest, "doctor: starting diagnostic")
+
+	reachable := true
+
+	dnsResults, err := Lookup(dest)
+	if err != nil {
+		LogDestinationError(dest, "doctor: DNS lookup failed", err)
+		return false
+	}
+
+	if len(dnsResults) == 0 {
+		LogDestination(dest, "doctor: DNS returned no addresses")
+		return false
+	}
+
+	for _, ip := range dnsResults {
+		if strings.Contains(ip.String(), ":") {
+			LogDestination(dest, "doctor: skipping IPv6 address "+ip.String())
+			continue
+		}
+
+		LogDestination(dest, "doctor: DNS resolved "+ip.String())
+
+		route, routeErr := GetRoute(ip)
+		if routeErr != nil {
+			LogDestination(dest, fmt.Sprintf("doctor: route lookup unavailable for %s (continuing): %v", ip.String(), routeErr))
+		} else {
+			LogRoute(route, "doctor: route for "+ip.String())
+		}
+
+		var layerOK bool
+		if dest.Protocol == "icmp" {
+			layerOK = Ping(route, dest, ip)
+		} else {
+			layerOK = Dial(route, dest, ip)
+		}
+		if !layerOK {
+			reachable = false
+		}
+	}
+
+	if dest.Scheme == "http" || dest.Scheme == "https" {
+		if !doctorHTTPS(dest) {
+			reachable = false
+		}
+	}
+
+	if reachable {
+		LogDestination(dest, "doctor: all layers passed")
+	} else {
+		LogDestination(dest, "doctor: one or more layers failed")
+	}
+
+	return reachable
+}
+
+func doctorHTTPS(dest *Destination) bool {
+	LogDestination(dest, "doctor: HTTP GET "+dest.URL)
+
+	resp, err := http.Get(dest.URL)
+	if err != nil {
+		LogDestinationError(dest, "doctor: HTTP GET failed", err)
+		return false
+	}
+	defer resp.Body.Close()
+
+	LogDestination(dest, fmt.Sprintf("doctor: HTTP status %s", resp.Status))
+
+	snippet, readErr := io.ReadAll(io.LimitReader(resp.Body, 256))
+	if readErr != nil {
+		LogDestination(dest, fmt.Sprintf("doctor: could not read response body: %v", readErr))
+	} else if len(snippet) > 0 {
+		LogDestination(dest, fmt.Sprintf("doctor: response body (first %d bytes): %q", len(snippet), snippet))
+	} else {
+		LogDestination(dest, "doctor: response body empty")
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		LogDestination(dest, fmt.Sprintf("doctor: unexpected HTTP status %d", resp.StatusCode))
+		return false
+	}
+
+	return true
+}
+
+func DoctorLoop(destinations []*Destination) bool {
+	ok := true
+	for _, dest := range destinations {
+		if !dest.Doctor() {
+			ok = false
+		}
+	}
+	return ok
+}

--- a/doctor_test.go
+++ b/doctor_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestDoctorHTTPS_StatusAndBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok-body"))
+	}))
+	t.Cleanup(srv.Close)
+
+	dest := newTestDestination(t, srv.URL)
+	dest.Scheme = "http"
+
+	if !doctorHTTPS(dest) {
+		t.Fatal("doctorHTTPS() = false; want true")
+	}
+}
+
+func TestDoctorHTTPS_Non2xxFails(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(srv.Close)
+
+	dest := newTestDestination(t, srv.URL)
+	dest.Scheme = "http"
+
+	if doctorHTTPS(dest) {
+		t.Fatal("doctorHTTPS() = true; want false for 503")
+	}
+}

--- a/help.go
+++ b/help.go
@@ -35,6 +35,7 @@ func PrintUsage() {
 	fmt.Println("  check            Check all connectivity once and exit")
 	fmt.Println("  wait             Wait for all connectivity to be validated successfully")
 	fmt.Println("  monitor          Continuously monitor all connectivity forever")
+	fmt.Println("  doctor           Verbose end-to-end diagnostic for one or more URLs")
 	fmt.Println("  validate-config  Load config without making any network requests")
 	fmt.Println("  version          Show version information")
 	fmt.Println("  help             Show this help text")
@@ -65,6 +66,15 @@ func PrintCommandUsage(command string) bool {
 		fmt.Println("")
 		fmt.Println("This is useful to run as a daemon for continuously monitoring network")
 		fmt.Println("dependencies. The results of each check are emitted via statsd.")
+	} else if command == "doctor" {
+		fmt.Println("Run DNS, route, dial/ping, and HTTP(S) checks with verbose output.")
+		fmt.Println("")
+		fmt.Println("Usage: connectivity doctor <url> [urls...]")
+		fmt.Println("")
+		fmt.Println("Exit codes:")
+		fmt.Println("  0  All layers passed for every URL")
+		fmt.Println("  1  At least one layer failed")
+		fmt.Println("  2  URL parse failure")
 	} else if command == "version" {
 		fmt.Println("Show version information about this build")
 		fmt.Println("")


### PR DESCRIPTION
## Summary

- Add `connectivity doctor <url> [urls...]` for incident triage.
- Log DNS results, route selection, dial/ping outcome, and HTTP status plus a 256-byte body snippet.
- Exit 0 when all layers pass, 1 when any layer fails (same spirit as `check`).

## Test plan

- [x] `go build ./...`
- [x] `go test -run TestDoctor`
- [x] `go test -short ./...` (pre-existing `TestMinimalPostgresUrl` still requires local Postgres)

Partial fix for #41 (TLS cert details and global `-v` flag tracked separately).