### PR TITLE
fix: escape newline and CR in statsd tag values

### DIFF
--- a/statsd.go
+++ b/statsd.go
@@ -36,6 +36,8 @@ func EscapeTag(s string) string {
 	s = strings.Replace(s, "|", "-", -1)
 	s = strings.Replace(s, ",", "-", -1)
 	s = strings.Replace(s, "@", "-", -1)
+	s = strings.Replace(s, "\n", "-", -1)
+	s = strings.Replace(s, "\r", "-", -1)
 	return s
 }
 

--- a/statsd_test.go
+++ b/statsd_test.go
@@ -46,6 +46,9 @@ func TestEscapeTag(t *testing.T) {
 		{name: "comma", in: "a,b", want: "a-b"},
 		{name: "at", in: "a@b", want: "a-b"},
 		{name: "all_specials_combined", in: "a:b|c,d@e", want: "a-b-c-d-e"},
+		{name: "newline", in: "a\nb", want: "a-b"},
+		{name: "carriage_return", in: "a\rb", want: "a-b"},
+		{name: "crlf", in: "a\r\nb", want: "a--b"},
 		{name: "no_specials_unchanged", in: "plain.tag_value-1", want: "plain.tag_value-1"},
 		{name: "empty_string", in: "", want: ""},
 	}
@@ -59,33 +62,6 @@ func TestEscapeTag(t *testing.T) {
 	}
 }
 
-// TestEscapeTag_DoesNotEscapeNewlineOrCR documents the missing newline/CR
-// escaping in EscapeTag (#14). The wire-protocol injection risk is that a tag
-// containing a newline ends the current statsd message and starts a new one
-// the collector parses separately.
-//
-// Refs #14 — flip when fixed: once EscapeTag also rewrites \n and \r, the
-// expected values below should change to "a-b" and the test name's assertion
-// flipped to require sanitization.
-func TestEscapeTag_DoesNotEscapeNewlineOrCR(t *testing.T) {
-	cases := []struct {
-		name string
-		in   string
-		want string // current (buggy) behavior: passes the newline/CR through
-	}{
-		{name: "newline_passes_through", in: "a\nb", want: "a\nb"},
-		{name: "carriage_return_passes_through", in: "a\rb", want: "a\rb"},
-		{name: "crlf_passes_through", in: "a\r\nb", want: "a\r\nb"},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			got := EscapeTag(tc.in)
-			if got != tc.want {
-				t.Errorf("EscapeTag(%q) = %q; want %q (current buggy behavior — #14)", tc.in, got, tc.want)
-			}
-		})
-	}
-}
 
 func TestCount_WireFormat(t *testing.T) {
 	t.Cleanup(func() { drainQueue(t) })


### PR DESCRIPTION
## Summary

Fixes #14. `EscapeTag` now replaces `\n` and `\r` with `-`, matching the existing handling for `:`, `|`, `,`, and `@`. This prevents tag values from injecting extra statsd wire-protocol messages.

## Changes

- Extend `EscapeTag` in `statsd.go`
- Add newline/CR cases to `TestEscapeTag`
- Remove the regression test that documented the old buggy behavior

## Test plan

- [x] `go test -short ./... -run EscapeTag`
- [ ] Full `go test -short ./...` (fails locally on `TestMinimalPostgresUrl` without Postgres — pre-existing on main)