### PR TITLE
feat: add --timeout flag to wait subcommand

### DIFF
--- a/connectivity.go
+++ b/connectivity.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"log"
+	"time"
 	"os"
 	"sync"
 )
@@ -57,8 +58,18 @@ func main() {
 		urls := GetURLs(config)
 		destinations := ParseDestinations(urls)
 		ShowDestinations(destinations)
-		log.Print("Waiting until all connectivity is validated...")
-		WaitLoop(destinations)
+		timeout, err := parseWaitTimeout(os.Args[2:])
+		if err != nil {
+			log.Fatal(err)
+		}
+		if timeout > 0 {
+			log.Printf("Waiting until all connectivity is validated (timeout %v)...", timeout)
+		} else {
+			log.Print("Waiting until all connectivity is validated...")
+		}
+		if !WaitLoop(destinations, timeout) {
+			os.Exit(2)
+		}
 	} else if command == "monitor" {
 		configPath, _ := FindConfig()
 		config := LoadConfig(configPath)
@@ -152,17 +163,30 @@ func CheckLoop(destinations []*Destination) bool {
 	return reachable
 }
 
-func WaitLoop(destinations []*Destination) {
-	var wg sync.WaitGroup
-	for _, dest := range destinations {
-		wg.Add(1)
-		go func(dest *Destination) {
-			defer wg.Done()
-			dest.WaitFor()
-		}(dest)
+func WaitLoop(destinations []*Destination, timeout time.Duration) bool {
+	var deadline time.Time
+	if timeout > 0 {
+		deadline = time.Now().Add(timeout)
 	}
 
+	var wg sync.WaitGroup
+	okCh := make(chan bool, len(destinations))
+	for _, dest := range destinations {
+		wg.Add(1)
+		go func(d *Destination) {
+			defer wg.Done()
+			okCh <- d.WaitForUntil(deadline)
+		}(dest)
+	}
 	wg.Wait()
+	close(okCh)
+
+	for ok := range okCh {
+		if !ok {
+			return false
+		}
+	}
+	return true
 }
 
 func MonitorLoop(destinations []*Destination) {

--- a/destinations.go
+++ b/destinations.go
@@ -213,15 +213,33 @@ func (dest *Destination) Monitor() {
 	}
 }
 
-func (dest *Destination) WaitFor() {
+func (dest *Destination) WaitForUntil(deadline time.Time) bool {
 	for {
-		reachable := dest.Check()
-
-		if reachable {
-			LogDestination(dest, "Connected")
-			return
+		if !deadline.IsZero() && time.Now().After(deadline) {
+			LogDestinationError(dest, "Timed out waiting for connectivity", fmt.Errorf("deadline exceeded"))
+			return false
 		}
 
-		time.Sleep(15 * time.Second)
+		if dest.Check() {
+			LogDestination(dest, "Connected")
+			return true
+		}
+
+		sleep := 15 * time.Second
+		if !deadline.IsZero() {
+			remaining := time.Until(deadline)
+			if remaining <= 0 {
+				LogDestinationError(dest, "Timed out waiting for connectivity", fmt.Errorf("deadline exceeded"))
+				return false
+			}
+			if remaining < sleep {
+				sleep = remaining
+			}
+		}
+		time.Sleep(sleep)
 	}
+}
+
+func (dest *Destination) WaitFor() {
+	dest.WaitForUntil(time.Time{})
 }

--- a/help.go
+++ b/help.go
@@ -53,7 +53,8 @@ func PrintCommandUsage(command string) bool {
 	} else if command == "wait" || command == "waitfor" {
 		fmt.Println("Wait for all specified connectivity to be validated successfully at least once.")
 		fmt.Println("")
-		fmt.Println("Usage: connectivity [wait|waitfor] [urls]")
+		fmt.Println("Usage: connectivity [wait|waitfor] [--timeout DURATION]")
+		fmt.Println("  --timeout DURATION  Exit with code 2 if dependencies are not ready in time (e.g. 5m, 90s)")
 		fmt.Println("")
 		fmt.Println("This is useful when you need to wait for DNS propogation, a process to start")
 		fmt.Println("listening, configuration to be applied, etc, before doing something else. The")

--- a/wait_flags.go
+++ b/wait_flags.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+// parseWaitTimeout scans args for --timeout / -timeout and returns the duration.
+// A zero duration means wait indefinitely (current default behavior).
+func parseWaitTimeout(args []string) (time.Duration, error) {
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--timeout", "-timeout":
+			if i+1 >= len(args) {
+				return 0, fmt.Errorf("missing value for %s", args[i])
+			}
+			d, err := time.ParseDuration(args[i+1])
+			if err != nil {
+				return 0, fmt.Errorf("invalid timeout %q: %w", args[i+1], err)
+			}
+			if d <= 0 {
+				return 0, fmt.Errorf("timeout must be positive, got %v", d)
+			}
+			return d, nil
+		}
+	}
+	return 0, nil
+}

--- a/wait_flags_test.go
+++ b/wait_flags_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseWaitTimeout(t *testing.T) {
+	cases := []struct {
+		name    string
+		args    []string
+		want    time.Duration
+		wantErr bool
+	}{
+		{name: "empty", args: nil, want: 0},
+		{name: "five_minutes", args: []string{"--timeout", "5m"}, want: 5 * time.Minute},
+		{name: "short_flag", args: []string{"-timeout", "30s"}, want: 30 * time.Second},
+		{name: "missing_value", args: []string{"--timeout"}, wantErr: true},
+		{name: "invalid_duration", args: []string{"--timeout", "nope"}, wantErr: true},
+		{name: "non_positive", args: []string{"--timeout", "0s"}, wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseWaitTimeout(tc.args)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tc.want {
+				t.Fatalf("parseWaitTimeout() = %v; want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/wait_test.go
+++ b/wait_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"runtime"
+	"testing"
+	"time"
+)
+
+func TestWaitForUntil_TimesOut(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("GetRoute is only implemented on Linux")
+	}
+
+	t.Cleanup(func() { drainQueue(t) })
+	drainQueue(t)
+
+	dest := &Destination{
+		Label:    "unreachable",
+		URL:      "http://127.0.0.1:1/",
+		Protocol: "tcp",
+		Scheme:   "http",
+		Host:     "127.0.0.1",
+		Port:     1,
+	}
+
+	deadline := time.Now().Add(50 * time.Millisecond)
+	start := time.Now()
+	if dest.WaitForUntil(deadline) {
+		t.Fatal("WaitForUntil() = true; want false on timeout")
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("WaitForUntil took %v; expected to return near deadline", elapsed)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #18. Adds `connectivity wait --timeout DURATION` (e.g. `5m`, `90s`). When the deadline passes before all destinations connect, the process exits with code **2**.

## Changes

- `parseWaitTimeout` for `--timeout` / `-timeout`
- `WaitForUntil` respects an optional deadline with truncated sleep intervals
- `WaitLoop` returns false when any destination times out

## Test plan

- [x] `go test -short ./... -run 'Wait|ParseWait'`