### PR TITLE
fix: multi-sample ICMP, dial retry, and monitor jitter

### DIFF
--- a/destinations.go
+++ b/destinations.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"math/rand"
 	"fmt"
 	"net"
 	"net/url"
@@ -195,6 +196,9 @@ func (dest *Destination) Check() bool {
 }
 
 func (dest *Destination) Monitor() {
+	// Stagger the first check so destinations do not probe in lockstep (#20).
+	time.Sleep(time.Duration(rand.Int63n(int64(time.Minute))))
+
 	confidence := 1
 
 	for {

--- a/dialer.go
+++ b/dialer.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"net"
+	"time"
 )
 
 // Try to open a connection to the destination, and then immediately disconnect
@@ -12,15 +13,22 @@ func Dial(route *Route, dest *Destination, ip net.IP) bool {
 	metricTags := []string{fmt.Sprintf("dest_ip:%s", ip.String())}
 	hostPort := fmt.Sprintf("%s:%d", ip.String(), dest.Port)
 
-	// Test destination IP by dialing route
-	dest.Increment("connectivity.dial", metricTags)
-	conn, err := net.Dial(dest.Protocol, hostPort)
-	if err != nil {
-		dest.Increment("connectivity.dial.error", metricTags)
-		LogRouteDestinationError(route, dest, "Failed", err)
-		return false
+	var lastErr error
+	for attempt := 0; attempt < 2; attempt++ {
+		dest.Increment("connectivity.dial", metricTags)
+		conn, err := net.Dial(dest.Protocol, hostPort)
+		if err == nil {
+			_ = conn.Close()
+			dest.Increment("connectivity.dial.success", metricTags)
+			return true
+		}
+		lastErr = err
+		if attempt == 0 {
+			time.Sleep(100 * time.Millisecond)
+		}
 	}
-	defer conn.Close()
-	dest.Increment("connectivity.dial.success", metricTags)
-	return true
+
+	dest.Increment("connectivity.dial.error", metricTags)
+	LogRouteDestinationError(route, dest, "Failed", lastErr)
+	return false
 }

--- a/pinger.go
+++ b/pinger.go
@@ -3,9 +3,20 @@ package main
 import (
 	"fmt"
 	"net"
+	"time"
 
 	probing "github.com/prometheus-community/pro-bing"
 )
+
+const (
+	icmpProbeCount     = 3
+	icmpProbeInterval  = 200 * time.Millisecond
+)
+
+// icmpProbeSucceeded reports whether enough probe replies arrived.
+func icmpProbeSucceeded(packetsRecv int, probeCount int) bool {
+	return packetsRecv >= (probeCount+1)/2
+}
 
 func Ping(route *Route, dest *Destination, ip net.IP) bool {
 	pinger, err := probing.NewPinger(ip.String())
@@ -14,7 +25,8 @@ func Ping(route *Route, dest *Destination, ip net.IP) bool {
 		LogRouteError(route, fmt.Sprintf("Failed to setup ping to %s", ip.String()), err)
 		return false
 	}
-	pinger.Count = 1
+	pinger.Count = icmpProbeCount
+	pinger.Interval = icmpProbeInterval
 	err = pinger.Run()
 	if err != nil {
 		dest.Increment("connectivity.icmp.error", []string{})
@@ -22,8 +34,14 @@ func Ping(route *Route, dest *Destination, ip net.IP) bool {
 		return false
 	}
 
-	// Emit metrics
 	stats := pinger.Statistics()
+	if !icmpProbeSucceeded(int(stats.PacketsRecv), icmpProbeCount) {
+		dest.Increment("connectivity.icmp.error", []string{})
+		LogRouteError(route, fmt.Sprintf("Insufficient ping replies from %s (%d/%d received)", ip.String(), stats.PacketsRecv, icmpProbeCount), fmt.Errorf("packet loss %.0f%%", stats.PacketLoss))
+		return false
+	}
+
+	Gauge("connectivity.icmp.packet_loss_pct", int(stats.PacketLoss), dest.tags())
 	dest.Increment("connectivity.icmp.success", []string{})
 	dest.Timer("connectivity.icmp", stats.AvgRtt, []string{})
 

--- a/pinger_test.go
+++ b/pinger_test.go
@@ -1,0 +1,27 @@
+package main
+
+import "testing"
+
+func TestIcmpProbeSucceeded(t *testing.T) {
+	cases := []struct {
+		name        string
+		packetsRecv int
+		probeCount  int
+		want        bool
+	}{
+		{name: "zero_of_three", packetsRecv: 0, probeCount: 3, want: false},
+		{name: "one_of_three", packetsRecv: 1, probeCount: 3, want: false},
+		{name: "two_of_three", packetsRecv: 2, probeCount: 3, want: true},
+		{name: "three_of_three", packetsRecv: 3, probeCount: 3, want: true},
+		{name: "two_of_five", packetsRecv: 2, probeCount: 5, want: false},
+		{name: "three_of_five", packetsRecv: 3, probeCount: 5, want: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := icmpProbeSucceeded(tc.packetsRecv, tc.probeCount)
+			if got != tc.want {
+				t.Fatalf("icmpProbeSucceeded(%d, %d) = %v; want %v", tc.packetsRecv, tc.probeCount, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #20.

- **ICMP:** 3 probes at 200ms intervals; success when a majority reply; emit packet-loss gauge
- **Dial:** one retry after 100ms for transient SYN loss
- **Monitor:** random delay up to 1 minute before the first check per destination

## Test plan

- [x] `go test -short ./... -run IcmpProbe`
- [x] `go build ./...`