### PR TITLE
fix: drain statsd on monitor shutdown signal

### DIFF
--- a/connectivity.go
+++ b/connectivity.go
@@ -3,7 +3,10 @@ package main
 import (
 	"log"
 	"os"
+	"os/signal"
 	"sync"
+	"syscall"
+	"time"
 )
 
 /*
@@ -67,7 +70,7 @@ func main() {
 		destinations := ParseDestinations(urls)
 		ShowDestinations(destinations)
 		log.Print("Monitoring connectivity...")
-		MonitorLoop(destinations)
+		MonitorLoop(config, destinations)
 	} else if command == "version" {
 		PrintVersion()
 	} else if command == "help" {
@@ -165,11 +168,14 @@ func WaitLoop(destinations []*Destination) {
 	wg.Wait()
 }
 
-func MonitorLoop(destinations []*Destination) {
+func MonitorLoop(config *Config, destinations []*Destination) {
 	for _, dest := range destinations {
 		go dest.Monitor()
 	}
 
-	// Sleep forever
-	select {}
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	<-sigCh
+	log.Print("Received shutdown signal, draining statsd...")
+	DrainStatsd(config, 5*time.Second)
 }

--- a/statsd.go
+++ b/statsd.go
@@ -39,12 +39,31 @@ func EscapeTag(s string) string {
 	return s
 }
 
+func emitStatsd(config *Config, payload string) {
+	statsdHostPort := fmt.Sprintf("%s:%d", config.StatsdHost, config.StatsdPort)
+	conn, err := net.Dial(config.StatsdProtocol, statsdHostPort)
+	if err != nil {
+		return
+	}
+	_, _ = io.WriteString(conn, payload)
+	_ = conn.Close()
+}
+
 func StatsdSender(config *Config) {
 	for s := range queue {
-		statsdHostPort := fmt.Sprintf("%s:%d", config.StatsdHost, config.StatsdPort)
-		if conn, err := net.Dial(config.StatsdProtocol, statsdHostPort); err == nil {
-			io.WriteString(conn, s)
-			conn.Close()
+		emitStatsd(config, s)
+	}
+}
+
+// DrainStatsd flushes queued metrics for up to timeout before process exit.
+func DrainStatsd(config *Config, timeout time.Duration) {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		select {
+		case s := <-queue:
+			emitStatsd(config, s)
+		default:
+			return
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Part of #17. `monitor` now handles SIGINT/SIGTERM, logs shutdown, and drains the statsd queue for up to 5s via `DrainStatsd` instead of exiting immediately with buffered metrics dropped.

## Test plan

- [x] `go build ./...`
- [x] `go test -short ./... -run Statsd`